### PR TITLE
Remove reference to vbarray.js

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,8 +12,7 @@
       "node_modules/openlayers/externs/geojson.js",
       "node_modules/openlayers/externs/proj4js.js",
       "node_modules/openlayers/externs/tilejson.js",
-      "node_modules/openlayers/externs/topojson.js",
-      "node_modules/openlayers/externs/vbarray.js"
+      "node_modules/openlayers/externs/topojson.js"
     ],
     "define": [
       "goog.array.ASSUME_NATIVE_FUNCTIONS=true",


### PR DESCRIPTION
This file was removed with https://github.com/openlayers/ol3/pull/3516.

Fixes #1.
